### PR TITLE
Fix undefined array key warnings breaking JSON response in getAllHeaders

### DIFF
--- a/tester.php
+++ b/tester.php
@@ -78,7 +78,7 @@ function handleApiRequest(string $queryString): string
         elseif ($params['test'] === 'getAllHeaders' && isset($params['testVal']))
         {
             // $setAcceptHeaders = isset($params['setHeaders']) ? true : false;
-            $headersResult = getCustomHeaders($params['testVal'], $params['mediaType'], $params['lang']);
+            $headersResult = getCustomHeaders($params['testVal'], $params['mediaType'] ?? null, $params['lang'] ?? null);
             $resultObj = [
                 "test" => $params['test'],
                 "testVal" => $params['testVal'],


### PR DESCRIPTION
$params['mediaType'] and $params['lang'] are optional query parameters that may not be present in every request. In PHP 8, accessing a missing array key emits a Warning that, with display_errors enabled, gets prepended to the JSON response body and makes it unparseable by the JavaScript test runner.

Fixed by using null-coalescing operators so absent params default to null rather than triggering a warning.