### PR TITLE
Forward linkType and context query params to resolver URL in getAllHeaders

### DIFF
--- a/tester.php
+++ b/tester.php
@@ -80,9 +80,45 @@ function handleApiRequest(string $queryString): string
             // linkType and context are resolver query params; mediaType and lang become HTTP headers
             $uri = $params['testVal'];
             $uriParams = [];
-            if (isset($params['linkType'])) { $uriParams[] = 'linkType=' . urlencode($params['linkType']); }
-            if (isset($params['context']))  { $uriParams[] = 'context='  . urlencode($params['context']);  }
-            if (!empty($uriParams)) { $uri .= '?' . implode('&', $uriParams); }
+            if (isset($params['linkType'])) { $uriParams['linkType'] = $params['linkType']; }
+            if (isset($params['context']))  { $uriParams['context'] = $params['context']; }
+            if (!empty($uriParams)) {
+                $parsedUri = parse_url($uri);
+                if ($parsedUri !== false) {
+                    $existingQueryParams = [];
+                    if (isset($parsedUri['query'])) {
+                        parse_str($parsedUri['query'], $existingQueryParams);
+                    }
+                    $mergedQueryParams = array_merge($existingQueryParams, $uriParams);
+                    $rebuiltUri = '';
+                    if (isset($parsedUri['scheme'])) {
+                        $rebuiltUri .= $parsedUri['scheme'] . '://';
+                    }
+                    if (isset($parsedUri['user'])) {
+                        $rebuiltUri .= $parsedUri['user'];
+                        if (isset($parsedUri['pass'])) {
+                            $rebuiltUri .= ':' . $parsedUri['pass'];
+                        }
+                        $rebuiltUri .= '@';
+                    }
+                    if (isset($parsedUri['host'])) {
+                        $rebuiltUri .= $parsedUri['host'];
+                    }
+                    if (isset($parsedUri['port'])) {
+                        $rebuiltUri .= ':' . $parsedUri['port'];
+                    }
+                    $rebuiltUri .= $parsedUri['path'] ?? '';
+
+                    $query = http_build_query($mergedQueryParams, '', '&', PHP_QUERY_RFC3986);
+                    if ($query !== '') {
+                        $rebuiltUri .= '?' . $query;
+                    }
+                    if (isset($parsedUri['fragment'])) {
+                        $rebuiltUri .= '#' . $parsedUri['fragment'];
+                    }
+                    $uri = $rebuiltUri;
+                }
+            }
             $headersResult = getCustomHeaders($uri, $params['mediaType'] ?? null, $params['lang'] ?? null);
             $resultObj = [
                 "test" => $params['test'],

--- a/tester.php
+++ b/tester.php
@@ -77,8 +77,13 @@ function handleApiRequest(string $queryString): string
         }
         elseif ($params['test'] === 'getAllHeaders' && isset($params['testVal']))
         {
-            // $setAcceptHeaders = isset($params['setHeaders']) ? true : false;
-            $headersResult = getCustomHeaders($params['testVal'], $params['mediaType'], $params['lang']);
+            // linkType and context are resolver query params; mediaType and lang become HTTP headers
+            $uri = $params['testVal'];
+            $uriParams = [];
+            if (isset($params['linkType'])) { $uriParams[] = 'linkType=' . urlencode($params['linkType']); }
+            if (isset($params['context']))  { $uriParams[] = 'context='  . urlencode($params['context']);  }
+            if (!empty($uriParams)) { $uri .= '?' . implode('&', $uriParams); }
+            $headersResult = getCustomHeaders($uri, $params['mediaType'] ?? null, $params['lang'] ?? null);
             $resultObj = [
                 "test" => $params['test'],
                 "testVal" => $params['testVal'],


### PR DESCRIPTION
The JS test runner sends linkType, context, mediaType and lang as separate query parameters to tester.php (e.g. ?test=getAllHeaders&testVal=... &linkType=gs1:pip&lang=de). Previously, linkType and context were parsed but silently discarded, so the cURL request to the resolver was made against the bare URL without ?linkType=... This caused the resolver to redirect to its default link rather than the requested link type, producing false failures for all per-link-type redirect tests.

Fixed by appending linkType and context as query parameters to the resolver URI before the cURL call. mediaType and lang correctly remain as Accept and Accept-Language HTTP headers.