### PR TITLE
Handle URL-encoded linkType in Location header and unexpected 300 responses

### DIFF
--- a/GS1DigitalLinkResolverTestSuite.js
+++ b/GS1DigitalLinkResolverTestSuite.js
@@ -1397,15 +1397,19 @@ const testMultipleLinks = async (dl, linkType, arrayOfLinkObjects, threehundredL
                 // Need to handle linkType in the target location query string whether on its own or added to existng query
                 let targetLocation = data.result.Location;
                 if (!targetLocation) {targetLocation = data.result.location}
-                if ((targetLocation) && (targetLocation.indexOf('?linkType='+linkType)) !== -1) {
+                const encodedLinkType = encodeURIComponent(linkType);
+                if ((targetLocation) && (targetLocation.indexOf('?linkType='+linkType) !== -1 || targetLocation.indexOf('?linkType='+encodedLinkType) !== -1)) {
                     targetLocation = stripQueryStringFromURL(targetLocation)
-                } else if ((targetLocation) &&  (targetLocation.indexOf('&linkType='+linkType) !== -1)) {
-                    targetLocation = targetLocation.substring(0, targetLocation.indexOf('&linkType='))
+                } else if ((targetLocation) && (targetLocation.indexOf('&linkType='+linkType) !== -1 || targetLocation.indexOf('&linkType='+encodedLinkType) !== -1)) {
+                    targetLocation = targetLocation.substring(0, targetLocation.indexOf(targetLocation.indexOf('&linkType='+linkType) !== -1 ? '&linkType='+linkType : '&linkType='+encodedLinkType))
                 }
                 // Now we can do the comparison
                 if (arrayOfLinkObjects[lo].href === targetLocation) {
                     loObject.status = 'pass';
                     loObject.msg = loObject.msg.replace('did not redirect', 'redirected')
+                } else if (data.result['httpCode'] === 300) {
+                    loObject.status = 'warn';
+                    loObject.msg = `Resolver returned 300 Multiple Choices when requesting linkType ${linkType} — unable to verify redirect to ${arrayOfLinkObjects[lo].href}`;
                 }
                 recordResult(loObject);
             } 


### PR DESCRIPTION
Two fixes in testMultipleLinks:

1. The stripping logic for linkType in the redirect Location header only checked for the unencoded form (e.g. gs1:pip). When a resolver echoes the linkType back URL-encoded (gs1%3Apip), the check failed and the parameter was not stripped before comparison. Now checks both encoded and unencoded forms.

2. When a resolver returns 300 Multiple Choices for a link type that the test expected to redirect (not in threehundredLinks), the test silently failed with no explanation. Now surfaces this as a warn with a message indicating the resolver returned 300 and verification was not possible.