### PR TITLE
Fixes #23 application/linkset+json with charset

### DIFF
--- a/GS1DigitalLinkResolverTestSuite.js
+++ b/GS1DigitalLinkResolverTestSuite.js
@@ -502,7 +502,7 @@ const headerBasedChecks = (dl) =>
                     (data.result['access-control-allow-methods'].indexOf('HEAD') > -1)) &&
                 (data.result['access-control-allow-methods'].indexOf('OPTIONS') > -1)))
         { // We have our three allowed methods
-            methodsCheck.msg = 'GET, HEAD an OPTIONS methods declared to be supported';
+            methodsCheck.msg = 'GET, HEAD and OPTIONS methods declared to be supported';
             methodsCheck.status = 'pass';
             recordResult(methodsCheck);
         }

--- a/GS1DigitalLinkResolverTestSuite.js
+++ b/GS1DigitalLinkResolverTestSuite.js
@@ -913,7 +913,7 @@ const fetchAndValidateTheLinkset = (dl) =>
                 } else if (resultObject.headers['Content-Type']) {
                     contentType = resultObject.headers['Content-Type'];
                 }
-                if (contentType === 'application/linkset+json') {
+                if (contentType.startsWith('application/linkset+json')) {
                     declaredContentType.status = 'pass';
                     declaredContentType.msg = 'Content type for the linkset retrieved from the resolver matches the requested application/linkset+json';
                 } else if (contentType === 'application/json') {


### PR DESCRIPTION
Fixes this part of #23 

> The test currently compares the Content-Type header against the literal string application/linkset+json. However, this causes the test to fail if a charset is included. In my case, the response header is application/linkset+json; charset=utf-8, which is a valid value.