### PR TITLE
Fix #28 - Query string not included in testVal

### DIFF
--- a/GS1DigitalLinkResolverTestSuite.js
+++ b/GS1DigitalLinkResolverTestSuite.js
@@ -1411,30 +1411,28 @@ const testMultipleLinks = async (dl, linkType, arrayOfLinkObjects, threehundredL
             } 
         }
         // In all cases, we need to construct the request with all the relevant parameters
-        let queryString = '';
+        let commandQueryString = '';
+        let urlQueryString = '?';
         if (linkType !== 'gs1:defaultLinkMulti') {
             // Never ask for defaultLinkMulti explicitly
-            queryString += '&linkType=' + encodeURIComponent(linkType);
+            urlQueryString += 'linkType=' + encodeURIComponent(linkType);
         }
         if (arrayOfLinkObjects[lo].type !== null) {
             loObject.msg += ` type: ${arrayOfLinkObjects[lo].type}`;
-            queryString += `&mediaType=${encodeURIComponent(arrayOfLinkObjects[lo].type)}`;
-            
+            commandQueryString += `&mediaType=${encodeURIComponent(arrayOfLinkObjects[lo].type)}`;
         }
         if (Array.isArray(arrayOfLinkObjects[lo].hreflang)) {
             loObject.msg += ` hreflang: ${arrayOfLinkObjects[lo].hreflang[0]}`;
-            queryString += `&lang=${arrayOfLinkObjects[lo].hreflang[0]}`;
+            commandQueryString += `&lang=${arrayOfLinkObjects[lo].hreflang[0]}`;
         }
         if ((arrayOfLinkObjects[lo].context !== undefined) && (Array.isArray(arrayOfLinkObjects[lo].context))) {
             loObject.msg += ` context: ${arrayOfLinkObjects[lo].context[0]}`;
-            queryString += `&context=${arrayOfLinkObjects[lo].context[0]}`;
+            urlQueryString += `&context=${arrayOfLinkObjects[lo].context[0]}`;
         } else if (arrayOfLinkObjects[lo].context !== undefined) {
-            // console.log(`here with something else and ${arrayOfLinkObjects[lo].context}`)
             loObject.msg += ` context: ${arrayOfLinkObjects[lo].context}`
-            queryString += `&context=${arrayOfLinkObjects[lo].context}`;
+            urlQueryString += `&context=${arrayOfLinkObjects[lo].context}`;
         }
-        loObject.url = testUri + '?test=getAllHeaders&testVal=' + encodeURIComponent(stripQueryStringFromURL(dl)) + queryString;
-        // console.log(`this one ${loObject.url}`)
+        loObject.url = testUri + '?test=getAllHeaders&testVal=' + encodeURIComponent(stripQueryStringFromURL(dl) + urlQueryString) + commandQueryString;
         recordResult(loObject);
         await runTest(loObject);
     }


### PR DESCRIPTION
Fixes #28 by setting the DigitalLink query string parameters to the testVal parameter sent to the request instead of setting in directly to the request. 

This is an example of the request sent to the tester.php:

Before:
`https://ref.gs1.org/test-suites/resolver/1.0.0/tester.php?test=getAllHeaders&testVal=https%3A%2F%2Fhostname%2F01%2F04047111050247&linkType=gs1%3Apip&mediaType=text%2Fhtml&lang=en`

After: `https://ref.gs1.org/test-suites/resolver/1.0.0/tester.php?test=getAllHeaders&testVal=https%3A%2F%2Fhostname%2F01%2F04047111050247%3FlinkType%3Dgs1%3Apip&mediaType=text%2Fhtml&lang=en`