### PR TITLE
Fix check for redirection with additional parameters

### DIFF
--- a/GS1DigitalLinkResolverTestSuite.js
+++ b/GS1DigitalLinkResolverTestSuite.js
@@ -1393,30 +1393,15 @@ const testMultipleLinks = async (dl, linkType, arrayOfLinkObjects, threehundredL
             loObject.msg = `Requesting linkType of ${linkType} with the following parameters did not redirect to ${arrayOfLinkObjects[lo].href}`;
             loObject.process = async (data) =>
             {
-                // Need to handle 'location' and 'Location'
-                // Need to handle linkType in the target location query string whether on its own or added to existng query
-                let targetLocation = data.result.Location;
-                if (!targetLocation) {targetLocation = data.result.location}
-                const encodedLinkType = encodeURIComponent(linkType);
-                if ((targetLocation) && (targetLocation.indexOf('?linkType='+linkType) !== -1 || targetLocation.indexOf('?linkType='+encodedLinkType) !== -1)) {
-                    targetLocation = stripQueryStringFromURL(targetLocation)
-                } else if ((targetLocation) && (targetLocation.indexOf('&linkType='+linkType) !== -1 || targetLocation.indexOf('&linkType='+encodedLinkType) !== -1)) {
-                    targetLocation = targetLocation.substring(0, targetLocation.indexOf(targetLocation.indexOf('&linkType='+linkType) !== -1 ? '&linkType='+linkType : '&linkType='+encodedLinkType))
+                const location = data.result.Location ?? data.result.location;
+
+                if (stripLinkType(location, linkType) === stripLinkType(arrayOfLinkObjects[lo].href, linkType)) {
+                    loObject.status = 'pass';
+                    loObject.msg = loObject.msg.replace('did not redirect', 'redirected')
+                } else if (data.result['httpCode'] === 300) {
+                    loObject.status = 'warn';
+                    loObject.msg = `Resolver returned 300 Multiple Choices when requesting linkType ${linkType} — unable to verify redirect to ${arrayOfLinkObjects[lo].href}`;
                 }
-                // Now we can do the comparison
-                if (arrayOfLinkObjects[lo].href === targetLocation) 
-                {
-                    const location = data.result.Location ?? data.result.location;
-                    
-                    if (stripLinkType(location, linkType) === stripLinkType(arrayOfLinkObjects[lo].href, linkType)) {
-                        loObject.status = 'pass';
-                        loObject.msg = loObject.msg.replace('did not redirect', 'redirected')
-                    } else if (data.result['httpCode'] === 300) {
-                        loObject.status = 'warn';
-                        loObject.msg = `Resolver returned 300 Multiple Choices when requesting linkType ${linkType} — unable to verify redirect to ${arrayOfLinkObjects[lo].href}`;
-                    }
-                }
-                recordResult(loObject);
             }
         }
         // In all cases, we need to construct the request with all the relevant parameters

--- a/GS1DigitalLinkResolverTestSuite.js
+++ b/GS1DigitalLinkResolverTestSuite.js
@@ -1406,16 +1406,14 @@ const testMultipleLinks = async (dl, linkType, arrayOfLinkObjects, threehundredL
                 // Now we can do the comparison
                 if (arrayOfLinkObjects[lo].href === targetLocation) 
                 {
-                    loObject.process = async (data) => 
-                    {
-                        const location = data.result.Location ?? data.result.location;
-                        if (stripLinkType(location, linkType) === stripLinkType(arrayOfLinkObjects[lo].href, linkType)) {
-                            loObject.status = 'pass';
-                            loObject.msg = loObject.msg.replace('did not redirect', 'redirected')
-                        } else if (data.result['httpCode'] === 300) {
-                            loObject.status = 'warn';
-                            loObject.msg = `Resolver returned 300 Multiple Choices when requesting linkType ${linkType} — unable to verify redirect to ${arrayOfLinkObjects[lo].href}`;
-                        }
+                    const location = data.result.Location ?? data.result.location;
+                    
+                    if (stripLinkType(location, linkType) === stripLinkType(arrayOfLinkObjects[lo].href, linkType)) {
+                        loObject.status = 'pass';
+                        loObject.msg = loObject.msg.replace('did not redirect', 'redirected')
+                    } else if (data.result['httpCode'] === 300) {
+                        loObject.status = 'warn';
+                        loObject.msg = `Resolver returned 300 Multiple Choices when requesting linkType ${linkType} — unable to verify redirect to ${arrayOfLinkObjects[lo].href}`;
                     }
                 }
                 recordResult(loObject);


### PR DESCRIPTION
The current test for redirection using additional parameters (lang, context, etc.) redefines the process method from inside the method itself but it is never called again; thus the test status is never set to 'pass' or 'warn'.

This change does the verification directly as we already have all the required information from the resolver's call. It also simplifies the validation to check the "location" header only once